### PR TITLE
Apply encodeUrl only when data is passed.

### DIFF
--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -417,7 +417,7 @@ class Request
         }
 
         $curl_base_options = [
-            CURLOPT_URL => self::encodeUrl($url),
+            CURLOPT_URL => $data ? self::encodeUrl($url) : $url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS => 10,


### PR DESCRIPTION
Query part can be constructed in the following manner into the URL:

* $url . '?' . http_build_query($data); /* uses PHP_QUERY_RFC1738 */
* $url . '?' . http_build_query($data, null, ini_get('arg_separator.output'), PHP_QUERY_RFC3986);

So when no $data is set - incoming $url should be assumed pre-built as required.