### PR TITLE
Fixed bug in request including array parameter

### DIFF
--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -405,6 +405,10 @@ class Request
 				curl_setopt(self::$handle, CURLOPT_CUSTOMREQUEST, $method);
 			}
 
+            if (is_array($body)) {
+                $body = http_build_query($body);
+            }
+            
             curl_setopt(self::$handle, CURLOPT_POSTFIELDS, $body);
         } elseif (is_array($body)) {
             if (strpos($url, '?') !== false) {


### PR DESCRIPTION
Fixed "Array to String conversion" error when you need request a body which included an Array parameter like: 
foo[]=1&foo[]=2