### PR TITLE
issue 156, avoid PHP 7.4 Notice (array offset on value of type int)

### DIFF
--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -555,7 +555,7 @@ class Request
             $query = '?' . http_build_query(self::getArrayFromQuerystring($query));
         }
 
-        if ($port && $port[0] !== ':') {
+        if ($port) {
             $port = ':' . $port;
         }
 


### PR DESCRIPTION
This should fix issue #156 - $port is an integer, and there is no reason to access it as an array or string.

I noticed there is no test for this, and don't know how to create one. Also, the UnirestRequestTest::testGzip test seems to be failing, but it already did that before my change.